### PR TITLE
Fix issue regarding keyboard accessibility on custom dropdowns.

### DIFF
--- a/src/components/partials/Grid.js
+++ b/src/components/partials/Grid.js
@@ -132,8 +132,7 @@ class Grid extends Component {
 
     updateGroups = (e, data) => {
         this.setState({
-            group: data.value,
-            groupLabel: e.target.textContent
+            group: data.value
         });
 
         this.sortGroups()
@@ -184,7 +183,6 @@ class Grid extends Component {
                         />
                         <Dropdown icon
                                   className="icon-down-open"
-                                  text={this.state.groupLabel}
                                   value={this.state.group}
                                   name="group"
                                   options={digital.groups}

--- a/src/components/partials/Search.js
+++ b/src/components/partials/Search.js
@@ -23,8 +23,6 @@ class Search extends Component {
     };
 
     updateType = (e, data) => {
-        console.log(data);
-
         this.setState({
             type: data.value
         });

--- a/src/components/partials/Search.js
+++ b/src/components/partials/Search.js
@@ -23,9 +23,10 @@ class Search extends Component {
     };
 
     updateType = (e, data) => {
+        console.log(data);
+
         this.setState({
-            type: data.value,
-            typeLabel: e.target.textContent
+            type: data.value
         });
     };
 
@@ -72,7 +73,6 @@ class Search extends Component {
                                 <input/>
                                 <Select icon
                                         compact
-                                        text={this.state.typeLabel}
                                         value={this.state.type}
                                         name="digital-resource"
                                         options={digital.searchOptions}


### PR DESCRIPTION
**JIRA Ticket**: [DCREDESIGN-16](https://jirautk.atlassian.net/browse/DCREDESIGN-16)

# What does this Pull Request do?

Fixes an issue with Semantic UI dropdowns where the upon Keyboard tabbing and arrow key press, the text label was filled by the all options rather than the one selected by the user.

**Reported Issue**
![image](https://user-images.githubusercontent.com/7376450/75572909-b2507e00-5a29-11ea-88db-5d0e06c90ea3.png)

**Expected Behavior**
![image](https://user-images.githubusercontent.com/7376450/75572989-ea57c100-5a29-11ea-802b-db7a6b890802.png)

# What's new?

* Removes `e.target.textContent` as on update state object.
* Removes attribute to populate Semantic UI `<Select>` with text label

# How should this be tested?

1. `git clone <repo>`
2. `cd <repo>`
3. `yarn && yarn build`
5. `git checkout <branch>`
4. `yarn start` (default browser should open with webapp)
5. Hit **`Tab`** until dropdown for All is shown.
6. Hit **`Down Arrow`** to select options.
7. Hit **`Tab`** until dropdown for All Collections is shown.
8. Hit **`Down Arrow`** to select options.
9. If text label updates to expected option, issue is fixed.

# Additional Notes:
Steps 1-3 are only required if this is the first time running the app locally.

# Interested parties
@DonRichards 
