### PR TITLE
Lower zindex on digital header to allow notice toggle to overlay.

### DIFF
--- a/src/scss/layout/_container.scss
+++ b/src/scss/layout/_container.scss
@@ -30,7 +30,7 @@ body > main {min-height: 400px;
 .utk-digital--header {
   width: 100%;
   position: relative;
-  z-index: 1;
+  z-index: 0;
   background-color: $smokey;
 
   @include respond(xs, sm) {


### PR DESCRIPTION
**What does this Pull Request do?**
At smaller vierwports for phone and tablet view, the toggle button partially overlays the digital header which currently has the same `z-index` as the notice component. Resolves by lowering the `z-index` value on the `.utk-digital--header` selector a notch below the notice.

![image](https://user-images.githubusercontent.com/7376450/78033685-b4fa0800-7334-11ea-8435-fa810a5b720e.png)

**What's new?**
Updates `z-index` on `.utk-digital--header` selector

**How should this be tested?**

1. `git clone <repo>`
2. `cd <repo>`
3. `yarn && yarn build`
4. `git pull`
5. `git checkout <branch>`
6. `yarn start`
7. Resize window to portrait tablet or phone width (less than 768 pixel wide)
8. Toggle button should be fully visible with the bottom half overlaying the digital header

**Additional Notes:**
Steps 1-3 are only required if this is the first time running the app locally.

**Interested parties**
@DonRichards

