### PR TITLE
Address DIT-1368 Revert z-index to resolve dropdown issue.

### DIFF
--- a/src/scss/layout/_container.scss
+++ b/src/scss/layout/_container.scss
@@ -30,7 +30,7 @@ body > main {min-height: 400px;
 .utk-digital--header {
   width: 100%;
   position: relative;
-  z-index: 0;
+  z-index: 1;
   background-color: $smokey;
 
   @include respond(xs, sm) {

--- a/src/scss/layout/_container.scss
+++ b/src/scss/layout/_container.scss
@@ -31,6 +31,7 @@ body > main {min-height: 400px;
   width: 100%;
   position: relative;
   z-index: 1;
+  overflow: unset;
   background-color: $smokey;
 
   @include respond(xs, sm) {


### PR DESCRIPTION
**What does this Pull Request do?**
The dropdown for Format does not extended beyond the header container in the expected manner. Resolves by adjusting the `z-index`  and `overflow` properties on the `.utk-digital--header`.

![image](https://user-images.githubusercontent.com/7376450/79759004-1ede4f80-82ec-11ea-8f3e-f34e7878ef78.png)

**What's new?**
Updates `z-index` and adds explicit `overflow: unset;` property on `.utk-digital--header` selector

**How should this be tested?**

1. `git clone <repo>`
2. `cd <repo>`
3. `yarn && yarn build`
4. `git pull`
5. `git checkout <branch>`
6. `yarn start`
7. Click the format dropdown **All** and test whether the listbox overlays the section below the header.

**Additional Notes:**
Steps 1-3 are only required if this is the first time running the app locally.

**Interested parties**
@DonRichards

