### PR TITLE
Address LazyLoad being less lazy

### DIFF
--- a/src/components/partials/ImageIIIF.js
+++ b/src/components/partials/ImageIIIF.js
@@ -75,8 +75,8 @@ class ImageIIIF extends Component {
                 <div className="utk-digital--image">
                     <LazyLoad once={true}
                               resize={true}
-                              offset={0}
-                              throttle={29}>
+                              offset={470}
+                              throttle={0}>
                         <Source src={source} />
                     </LazyLoad>
                     <span className="utk-digital--image--preload">

--- a/src/components/partials/ImageIIIF.js
+++ b/src/components/partials/ImageIIIF.js
@@ -76,7 +76,7 @@ class ImageIIIF extends Component {
                     <LazyLoad once={true}
                               resize={true}
                               offset={0}
-                              throttle={290}>
+                              throttle={29}>
                         <Source src={source} />
                     </LazyLoad>
                     <span className="utk-digital--image--preload">

--- a/src/scss/global/_variables.scss
+++ b/src/scss/global/_variables.scss
@@ -87,8 +87,8 @@ $golden-ratio-9: 521px;
 $transition-padding: padding 290ms ease-in-out;
 $transition-all: all 290ms ease-in-out;
 $transition-top: top 290ms ease-in-out;
-$transition-opacity: opacity 290ms ease-in-out;
-$transition-opacity-load: opacity 470ms ease-in-out;
+$transition-opacity: opacity 60ms ease-in-out;
+$transition-opacity-load: opacity 180ms ease-in-out;
 $transition-all-fast: all 110ms ease-in-out;
 $transition-all-load: all 470ms ease-in-out;
 


### PR DESCRIPTION
**What does this Pull Request do?**
Improves user experience of homepage by tightening loading of image assets from IIIF by updating throttle and offset params. Additionally, substantially tightens the CSS transition handling the roll-in of the image.

**How should this be tested?**

1. `git clone <repo>`
2. `cd <repo>`
3. `yarn && yarn build`
4. `git pull`
5. `git checkout <branch>`
6. `yarn start`
7. Scroll down the homepage. Image should be loading substantially faster. Images less than 470px below the bottom (set by offset param) of the browser window will begin loading process before scrolling to the relative image.

**Additional Notes:**
Steps 1-3 are only required if this is the first time running the app locally.

**Interested parties**
@DonRichards

