### PR TITLE
Further address lazyload issues and update alt attribute for images.

### DIFF
--- a/src/components/partials/ImageIIIF.js
+++ b/src/components/partials/ImageIIIF.js
@@ -14,15 +14,13 @@ class Source extends Component {
     };
 
     componentDidMount(){
-        setTimeout(() => {
-            this.setState({didMount: true})
-        }, 470)
+        this.setState({didMount: true})
     }
 
     render() {
         return (
             <figure className={`image-fade-in${this.state.didMount && ' image-visible'}`}>
-                <img src={this.props.src} />
+                <img src={this.props.src} alt={this.props.alt} />
             </figure>
         )
     }
@@ -77,17 +75,17 @@ class ImageIIIF extends Component {
                               resize={true}
                               offset={470}
                               throttle={0}>
-                        <Source src={source} />
+                        <Source src={source} alt={this.props.data.fgs_label_s} />
                     </LazyLoad>
                     <span className="utk-digital--image--preload">
-                        <img src={preload} />
+                        <img src={preload} alt={this.props.data.fgs_label_s} />
                     </span>
                 </div>
             )
         else
             return (
                 <span className="utk-digital--image-placeholder">
-                    <img src={placeholder} />
+                    <img src={placeholder} alt={this.props.data.fgs_label_s} />
                 </span>
             )
     }

--- a/src/scss/components/_image.scss
+++ b/src/scss/components/_image.scss
@@ -38,8 +38,10 @@
     background-color: $rock;
 
     > img {
+      display: block;
       filter: blur(18px);
       width: 100%;
+      height: 100%;
       object-fit: cover;
       transition: $transition-opacity;
       opacity: 0.85;


### PR DESCRIPTION
**What does this Pull Request do?**

Further improves user experience of homepage by removing timeout that was intended to showcase a cascading effect as you scrolled. As noted, this effect made the user experience feel sluggish and _powerpointy_. Additionally, updates alt attributes for all images.

**How should this be tested?**

1. `git clone <repo>`
2. `cd <repo>`
3. `yarn && yarn build`
4. `git pull`
5. `git checkout <branch>`
6. `yarn start`
7. Scroll down the homepage. Images should load immediately as your scroll with a very slight transition. 

**Additional Notes:**
Steps 1-3 are only required if this is the first time running the app locally.

**Interested parties**
@DonRichards

