### PR TITLE
Exclude rendering by abstract 

### DIFF
--- a/src/Digital.js
+++ b/src/Digital.js
@@ -48,8 +48,15 @@ class Digital extends Component {
             .then(data => {
 
                 remove(data.collections, function(collection) {
+
+                    // remove items if in explictly excluded
                     if (indexOf(digital.exclude, collection.PID) !== -1)
                         return collection
+
+                    // remove items if abstract does not exist
+                    if (!collection.hasOwnProperty("utk_mods_abstract_ms"))
+                        return collection
+
                 });
 
                 this.setState({
@@ -88,7 +95,7 @@ class Digital extends Component {
         let collections = this.state.collections;
 
         return (
-            <React.Fragment>
+                <React.Fragment>
                 {this.loadContent(collections)}
                 <div className={`utk-loading${this.state.dataLoad && ' utk-loading--loaded'}`}>
                     <div className="utk-loading--spinner"></div>

--- a/src/Digital.js
+++ b/src/Digital.js
@@ -49,7 +49,7 @@ class Digital extends Component {
 
                 remove(data.collections, function(collection) {
 
-                    // remove items if in explictly excluded
+                    // remove items if explictly excluded
                     if (indexOf(digital.exclude, collection.PID) !== -1)
                         return collection
 
@@ -95,7 +95,7 @@ class Digital extends Component {
         let collections = this.state.collections;
 
         return (
-                <React.Fragment>
+            <React.Fragment>
                 {this.loadContent(collections)}
                 <div className={`utk-loading${this.state.dataLoad && ' utk-loading--loaded'}`}>
                     <div className="utk-loading--spinner"></div>


### PR DESCRIPTION
https://jirautk.atlassian.net/browse/DIGITAL-861

**What does this Pull Request do?** 
Adds a soft check in the Digital Homepage to remove items from rendering if an abstract is unavailable in the JSON payload.

Previously, this block existed upon solr query and storing in the WordPress based mu-plugin. That functionality has been removed and is being tested, see: https://github.com/utkdigitalinitiatives/utk-libraries/commit/55ad267651a474c60cb8374d97888f4345805d65. That worked when this dataset was intended only for the digital homepage. However, now that we are needing to develop, test, and render banners for collections, we need this exclusion to happen later in the process. Thus, it has been moved to the React application house in this repo.

**How should this be tested?**

1.`cd <repo>`
2.` git checkout <branch>`
3.` yarn` OR `npm install`
4. Update line the **endpoint** on line 2 of `src/digital.json` to   `https://dev-utk-libraries.pantheonsite.io/wp-json/dc/all`
5. `yarn start` OR  `npm start`
6. Inspect the browser,  **menbase** should not be visible.
7. Browse to https://dev-utk-libraries.pantheonsite.io/wp-json/dc/all, do a find for **menbase**, the item should exist but have an abstract missing.
