### PR TITLE
Add WPA/TVA to digital homepage.

### DIFF
--- a/src/digital.json
+++ b/src/digital.json
@@ -12,8 +12,7 @@
     "arrowmont:arrscrap",
     "arrowmont:arrpgimg",
     "arrowmont:arrsimple",
-    "arrowmont:sturley",
-    "wpatva:open"
+    "arrowmont:sturley"
   ],
   "groups": [
     {


### PR DESCRIPTION
### What does this Pull Request do?

Removes the hardcoded exclusion of WPA/TVA, allowing it to be rendered to the digital.lib.utk.edu homepage.

### How should this be tested?

_If you care to..._

- `yarn && yarn start`
- browser should open at http://localhost:8081/ OR http://localhost:8080 (it's smart if there is a conflict)
- scroll down the homepage. WPA/TVA will be one of the collection items listed