### PR TITLE
changed z-index start to 1000

### DIFF
--- a/src/components/partials/Grid.js
+++ b/src/components/partials/Grid.js
@@ -18,7 +18,7 @@ class Collection extends Component {
         const pid = encodeURIComponent(data.PID)
         const url = `https://digital.lib.utk.edu/collections/islandora/object/${pid}`
         const viewClass = `utk-digital--collection ${view}`
-        const style = {zIndex: 100 - index}
+        const style = {zIndex: 1000 - index}
 
         // console.log(data)
 


### PR DESCRIPTION
### What this does
The starting index from 100 to 1000. This keeps the z-index in place just in case it is needed for mobile or other reasons.

### Why?
React partial component grid.js originally add z-index at 100 and runs down to 0 and if there are more objects than that it goes negative, which puts the object behind the background and cannot be clicked on.